### PR TITLE
Adding checks for empty userId or customer

### DIFF
--- a/Subscriber/PluginFrontendSubscriber.php
+++ b/Subscriber/PluginFrontendSubscriber.php
@@ -65,9 +65,16 @@ class PluginFrontendSubscriber extends AbstractSubscriber
                 )
             );
 
-            $userId = $controller->get('session')->get('sUserId');
+            $userId = $controller->get('session')->get('sUserId');            
+            if (empty($userId)) {
+                return;
+            }
+            
             /** @var Customer $customer */
             $customer = $controller->get('models')->find(Customer::class, $userId);
+            if (empty($customer)) {
+                return;
+            }
 
             /** @var ConfigurationServiceInterface $configurationService */
             $configurationService = $this->container->get('port1_hybrid_auth.configuration_service');


### PR DESCRIPTION
Adding checks for empty userId or customer to prevent error log entries when a bot or a not logged in user directly visits /account/profile route. Without the empty checks you will get three error entries in your shopware error log every time the route gets visit by a not logged in user/bot